### PR TITLE
docs: simplify installation to a single command

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,22 +11,10 @@ and if you have tmuxifier installed, you can uncomment the tmuxifier line in the
 
 ## Installation
 
-To use this repository, simply clone it to your local machine. 
+To use this repository, simply clone it and install the dotfiles with a single command.
 
 ```bash
-git clone https://github.com/codeopshq/dotfiles.git
-```
-
-Once cloned, navigate to the desired directory.
-
-```bash
-cd dotfiles
-```
-
-Run stow to install the dotfiles.
-
-```bash
-stow .
+git clone https://github.com/codeopshq/dotfiles.git && stow -d dotfiles -t ~ .
 ```
 
 You are now ready to use the dotfiles in your environment.


### PR DESCRIPTION
## Summary

- Replace the three-step installation (clone, cd, stow) with a single one-liner
- New command: `git clone <URL> && stow -d dotfiles -t ~ .`

## Test plan

- [ ] Clone the repo using the new command and verify stow applies the dotfiles correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Streamlined installation process with consolidated setup steps for easier deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->